### PR TITLE
De-ASM-ification - RenderManager#doRenderEntity

### DIFF
--- a/src/main/java/ValkyrienWarfareBase/Client/RenderManagerOverride.java
+++ b/src/main/java/ValkyrienWarfareBase/Client/RenderManagerOverride.java
@@ -28,6 +28,15 @@ public class RenderManagerOverride extends RenderManager {
 	 * INTERCEPT
 	 */
 
+	public boolean shouldRender(Entity entityIn, ICamera camera, double camX, double camY, double camZ){
+		return !ValkyrienWarfareMod.physicsManager.isEntityFixed(entityIn) && def.shouldRender(entityIn, camera, camX, camY, camZ);
+	}
+
+	public void renderEntityStatic(Entity p_188388_1_, float p_188388_2_, boolean p_188388_3_){
+		if(!ValkyrienWarfareMod.physicsManager.isEntityFixed(p_188388_1_))
+			def.renderEntityStatic(p_188388_1_, p_188388_2_, p_188388_3_);
+	}
+
 	public void doRenderEntity(Entity entityIn, double x, double y, double z, float yaw, float partialTicks, boolean p_188391_10_){
 		if(!ValkyrienWarfareMod.physicsManager.isEntityFixed(entityIn))
 			def.doRenderEntity(entityIn, x, y, z, yaw, partialTicks, p_188391_10_);
@@ -80,14 +89,6 @@ public class RenderManagerOverride extends RenderManager {
 
 	public boolean isRenderMultipass(Entity p_188390_1_){
 		return def.isRenderMultipass(p_188390_1_);
-	}
-
-	public boolean shouldRender(Entity entityIn, ICamera camera, double camX, double camY, double camZ){
-		return def.shouldRender(entityIn, camera, camX, camY, camZ);
-	}
-
-	public void renderEntityStatic(Entity p_188388_1_, float p_188388_2_, boolean p_188388_3_){
-		def.renderEntityStatic(p_188388_1_, p_188388_2_, p_188388_3_);
 	}
 
 	public void renderMultipass(Entity p_188389_1_, float p_188389_2_){

--- a/src/main/java/ValkyrienWarfareBase/Client/RenderManagerOverride.java
+++ b/src/main/java/ValkyrienWarfareBase/Client/RenderManagerOverride.java
@@ -1,0 +1,109 @@
+package ValkyrienWarfareBase.Client;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.renderer.culling.ICamera;
+import net.minecraft.client.renderer.entity.Render;
+import net.minecraft.client.renderer.entity.RenderManager;
+import net.minecraft.client.renderer.entity.RenderPlayer;
+import net.minecraft.client.settings.GameSettings;
+import net.minecraft.entity.Entity;
+import net.minecraft.world.World;
+
+public class RenderManagerOverride extends RenderManager {
+
+	private final RenderManager def;
+
+	public RenderManagerOverride(RenderManager def){
+		super(def.renderEngine, Minecraft.getMinecraft().getRenderItem());
+		this.def = def;
+	}
+
+	public Map<String, RenderPlayer> getSkinMap(){
+		return def.getSkinMap();
+	}
+
+	public void setRenderPosition(double renderPosXIn, double renderPosYIn, double renderPosZIn){
+		def.setRenderPosition(renderPosXIn, renderPosYIn, renderPosZIn);
+	}
+
+	public <T extends Entity> Render<T> getEntityClassRenderObject(Class<? extends Entity> entityClass){
+		return def.getEntityClassRenderObject(entityClass);
+	}
+
+	@Nullable
+	public <T extends Entity> Render<T> getEntityRenderObject(T entityIn){
+		return def.getEntityRenderObject(entityIn);
+	}
+
+	public void cacheActiveRenderInfo(World worldIn, FontRenderer textRendererIn, Entity livingPlayerIn, Entity pointedEntityIn, GameSettings optionsIn, float partialTicks){
+		def.cacheActiveRenderInfo(worldIn, textRendererIn, livingPlayerIn, pointedEntityIn, optionsIn, partialTicks);
+	}
+
+	public void setPlayerViewY(float playerViewYIn){
+		def.setPlayerViewY(playerViewYIn);
+	}
+
+	public boolean isRenderShadow(){
+		return def.isRenderShadow();
+	}
+
+	public void setRenderShadow(boolean renderShadowIn){
+		def.setRenderShadow(renderShadowIn);
+	}
+
+	public void setDebugBoundingBox(boolean debugBoundingBoxIn){
+		def.setDebugBoundingBox(debugBoundingBoxIn);
+	}
+
+	public boolean isDebugBoundingBox(){
+		return def.isDebugBoundingBox();
+	}
+
+	public boolean isRenderMultipass(Entity p_188390_1_){
+		return def.isRenderMultipass(p_188390_1_);
+	}
+
+	public boolean shouldRender(Entity entityIn, ICamera camera, double camX, double camY, double camZ){
+		return def.shouldRender(entityIn, camera, camX, camY, camZ);
+	}
+
+	public void renderEntityStatic(Entity p_188388_1_, float p_188388_2_, boolean p_188388_3_){
+		def.renderEntityStatic(p_188388_1_, p_188388_2_, p_188388_3_);
+	}
+
+	public void doRenderEntity(Entity entityIn, double x, double y, double z, float yaw, float partialTicks, boolean p_188391_10_){
+		def.doRenderEntity(entityIn, x, y, z, yaw, partialTicks, p_188391_10_);
+	}
+
+	public void renderMultipass(Entity p_188389_1_, float p_188389_2_){
+		def.renderMultipass(p_188389_1_, p_188389_2_);
+	}
+
+	/**
+	 * World sets this RenderManager's worldObj to the world provided
+	 */
+	public void set(@Nullable World worldIn){
+		def.set(worldIn);
+	}
+
+	public double getDistanceToCamera(double x, double y, double z){
+		return def.getDistanceToCamera(x, y, z);
+	}
+
+	/**
+	 * Returns the font renderer
+	 */
+	public FontRenderer getFontRenderer(){
+		return def.getFontRenderer();
+	}
+
+	public void setRenderOutlines(boolean renderOutlinesIn){
+		def.setRenderOutlines(renderOutlinesIn);
+	}
+
+}

--- a/src/main/java/ValkyrienWarfareBase/Client/RenderManagerOverride.java
+++ b/src/main/java/ValkyrienWarfareBase/Client/RenderManagerOverride.java
@@ -5,6 +5,8 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 import ValkyrienWarfareBase.ValkyrienWarfareMod;
+import ValkyrienWarfareBase.Render.PhysObjectRender;
+import ValkyrienWarfareBase.Render.PhysObjectRenderManager;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.culling.ICamera;
@@ -28,17 +30,21 @@ public class RenderManagerOverride extends RenderManager {
 	 * INTERCEPT
 	 */
 
+	private boolean shouldRender(Entity entity){
+		return PhysObjectRenderManager.renderingMountedEntities || !ValkyrienWarfareMod.physicsManager.isEntityFixed(entity);
+	}
+
 	public boolean shouldRender(Entity entityIn, ICamera camera, double camX, double camY, double camZ){
-		return !ValkyrienWarfareMod.physicsManager.isEntityFixed(entityIn) && def.shouldRender(entityIn, camera, camX, camY, camZ);
+		return shouldRender(entityIn) && def.shouldRender(entityIn, camera, camX, camY, camZ);
 	}
 
 	public void renderEntityStatic(Entity p_188388_1_, float p_188388_2_, boolean p_188388_3_){
-		if(!ValkyrienWarfareMod.physicsManager.isEntityFixed(p_188388_1_))
+		if(shouldRender(p_188388_1_))
 			def.renderEntityStatic(p_188388_1_, p_188388_2_, p_188388_3_);
 	}
 
 	public void doRenderEntity(Entity entityIn, double x, double y, double z, float yaw, float partialTicks, boolean p_188391_10_){
-		if(!ValkyrienWarfareMod.physicsManager.isEntityFixed(entityIn))
+		if(shouldRender(entityIn))
 			def.doRenderEntity(entityIn, x, y, z, yaw, partialTicks, p_188391_10_);
 	}
 

--- a/src/main/java/ValkyrienWarfareBase/Client/RenderManagerOverride.java
+++ b/src/main/java/ValkyrienWarfareBase/Client/RenderManagerOverride.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import ValkyrienWarfareBase.ValkyrienWarfareMod;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.culling.ICamera;
@@ -22,6 +23,19 @@ public class RenderManagerOverride extends RenderManager {
 		super(def.renderEngine, Minecraft.getMinecraft().getRenderItem());
 		this.def = def;
 	}
+
+	/*
+	 * INTERCEPT
+	 */
+
+	public void doRenderEntity(Entity entityIn, double x, double y, double z, float yaw, float partialTicks, boolean p_188391_10_){
+		if(!ValkyrienWarfareMod.physicsManager.isEntityFixed(entityIn))
+			def.doRenderEntity(entityIn, x, y, z, yaw, partialTicks, p_188391_10_);
+	}
+
+	/*
+	 * We don't care
+	 */
 
 	public Map<String, RenderPlayer> getSkinMap(){
 		return def.getSkinMap();
@@ -74,10 +88,6 @@ public class RenderManagerOverride extends RenderManager {
 
 	public void renderEntityStatic(Entity p_188388_1_, float p_188388_2_, boolean p_188388_3_){
 		def.renderEntityStatic(p_188388_1_, p_188388_2_, p_188388_3_);
-	}
-
-	public void doRenderEntity(Entity entityIn, double x, double y, double z, float yaw, float partialTicks, boolean p_188391_10_){
-		def.doRenderEntity(entityIn, x, y, z, yaw, partialTicks, p_188391_10_);
 	}
 
 	public void renderMultipass(Entity p_188389_1_, float p_188389_2_){

--- a/src/main/java/ValkyrienWarfareBase/CoreMod/CallRunnerClient.java
+++ b/src/main/java/ValkyrienWarfareBase/CoreMod/CallRunnerClient.java
@@ -465,12 +465,6 @@ public class CallRunnerClient extends CallRunner {
 		renderGlobal.renderEntities(renderViewEntity, camera, partialTicks);
 	}
 
-	public static void onDoRenderEntity(RenderManager manager, Entity entityIn, double x, double y, double z, float yaw, float partialTicks, boolean p_188391_10_){
-		if(!ValkyrienWarfareMod.physicsManager.isEntityFixed(entityIn)){
-			manager.doRenderEntity(entityIn, x, y, z, yaw, partialTicks, p_188391_10_);
-		}
-    }
-
 	public static boolean onInvalidateRegionAndSetBlock(WorldClient client, BlockPos pos, IBlockState state) {
 		int i = pos.getX();
 		int j = pos.getY();

--- a/src/main/java/ValkyrienWarfareBase/CoreMod/TransformAdapter.java
+++ b/src/main/java/ValkyrienWarfareBase/CoreMod/TransformAdapter.java
@@ -49,7 +49,6 @@ public class TransformAdapter extends ClassVisitor {
 	private static final String ViewFrustumName = "net/minecraft/client/renderer/ViewFrustum";
 	private static final String EntityRendererName = "net/minecraft/client/renderer/EntityRenderer";
 	private static final String FrustumName = "net/minecraft/client/renderer/culling/Frustum";
-	private static final String RenderManagerName = "net/minecraft/client/renderer/entity/RenderManager";
 
 	private static final String IteratorName = "java/util/Iterator";
 	private static final String PredicateName = "com/google/common/base/Predicate";
@@ -74,11 +73,6 @@ public class TransformAdapter extends ClassVisitor {
 		
 		if (isMethod(calledDesc, "(DF)L" + RayTraceResultName + ";", calledName, EntityClassName, "rayTrace", "func_174822_a", calledOwner)) {
 			mv.visitMethodInsn(Opcodes.INVOKESTATIC, ValkyrienWarfarePlugin.PathClient, "onRayTrace", String.format("(L%s;DF)L"+RayTraceResultName+";", EntityClassName));
-			return false;
-		}
-		
-		if (isMethod(calledDesc, "(L"+EntityClassName+";DDDFFZ)V", calledName, RenderManagerName, "doRenderEntity", "func_188391_a", calledOwner)) {
-			mv.visitMethodInsn(Opcodes.INVOKESTATIC, ValkyrienWarfarePlugin.PathClient, "onDoRenderEntity", String.format("(L%s;L"+EntityClassName+";DDDFFZ)V", RenderManagerName));
 			return false;
 		}
 		

--- a/src/main/java/ValkyrienWarfareBase/Proxy/ClientProxy.java
+++ b/src/main/java/ValkyrienWarfareBase/Proxy/ClientProxy.java
@@ -4,13 +4,16 @@ import ValkyrienWarfareBase.EventsClient;
 import ValkyrienWarfareBase.KeyHandler;
 import ValkyrienWarfareBase.ValkyrienWarfareMod;
 import ValkyrienWarfareBase.API.Vector;
+import ValkyrienWarfareBase.Client.RenderManagerOverride;
 import ValkyrienWarfareBase.Math.Quaternion;
 import ValkyrienWarfareBase.PhysicsManagement.PhysicsWrapperEntity;
 import ValkyrienWarfareBase.Render.PhysObjectRenderFactory;
+import code.elix_x.excomms.reflection.ReflectionHelper.AClass;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.client.renderer.culling.ICamera;
+import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.item.Item;
 import net.minecraftforge.client.model.obj.OBJLoader;
 import net.minecraftforge.common.MinecraftForge;
@@ -43,6 +46,7 @@ public class ClientProxy extends CommonProxy {
 	@Override
 	public void postInit(FMLPostInitializationEvent e) {
 		super.postInit(e);
+		new AClass<>(Minecraft.class).<RenderManager>getDeclaredField("renderManager").setAccessible(true).set(Minecraft.getMinecraft(), new RenderManagerOverride(Minecraft.getMinecraft().getRenderManager()));
 	}
 
 	private void registerBlockItem(Block toRegister) {

--- a/src/main/java/ValkyrienWarfareBase/Proxy/ClientProxy.java
+++ b/src/main/java/ValkyrienWarfareBase/Proxy/ClientProxy.java
@@ -11,6 +11,8 @@ import ValkyrienWarfareBase.Render.PhysObjectRenderFactory;
 import code.elix_x.excomms.reflection.ReflectionHelper.AClass;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.ItemRenderer;
+import net.minecraft.client.renderer.RenderGlobal;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.client.renderer.culling.ICamera;
 import net.minecraft.client.renderer.entity.RenderManager;
@@ -47,6 +49,8 @@ public class ClientProxy extends CommonProxy {
 	public void postInit(FMLPostInitializationEvent e) {
 		super.postInit(e);
 		new AClass<>(Minecraft.class).<RenderManager>getDeclaredField("renderManager").setAccessible(true).set(Minecraft.getMinecraft(), new RenderManagerOverride(Minecraft.getMinecraft().getRenderManager()));
+		new AClass<>(ItemRenderer.class).<RenderManager>getDeclaredField("renderManager").setAccessible(true).setFinal(false).set(Minecraft.getMinecraft().getItemRenderer(), Minecraft.getMinecraft().getRenderManager());
+		new AClass<>(RenderGlobal.class).<RenderManager>getDeclaredField("renderManager").setFinal(false).set(Minecraft.getMinecraft().renderGlobal, Minecraft.getMinecraft().getRenderManager());
 	}
 
 	private void registerBlockItem(Block toRegister) {

--- a/src/main/java/ValkyrienWarfareBase/Render/PhysObjectRenderManager.java
+++ b/src/main/java/ValkyrienWarfareBase/Render/PhysObjectRenderManager.java
@@ -39,6 +39,8 @@ import net.minecraftforge.client.ForgeHooksClient;
  */
 public class PhysObjectRenderManager {
 
+	public static boolean renderingMountedEntities = false;
+
 	public boolean needsSolidUpdate = true, needsCutoutUpdate = true, needsCutoutMippedUpdate = true, needsTranslucentUpdate = true;
 	public int glCallListSolid = -1;
 	public int glCallListTranslucent = -1;
@@ -209,6 +211,8 @@ public class PhysObjectRenderManager {
 	}
 
 	public void renderEntities(float partialTicks) {
+		renderingMountedEntities = true;
+
 		ArrayList<FixedEntityData> fixedEntities = new ArrayList();// ArrayList<FixedEntityData>) parent.fixedEntities.clone();
 		List<Entity> mountedEntities = parent.wrapper.riddenByEntities;
 		
@@ -267,6 +271,8 @@ public class PhysObjectRenderManager {
 			
 			}
 		}
+
+		renderingMountedEntities = false;
 	}
 
 	public boolean shouldRender() {


### PR DESCRIPTION
De-ASM-ified RenderManager#doRenderEntity using reflection load time replacement with override class intercepting methods we were patching with ASM.
Comes with minor performance improvements (indirectly reduces number of GL calls).
![Piggies!](http://i.imgur.com/7u1ZyfT.png)